### PR TITLE
Specify pid file location in systemd unit definition

### DIFF
--- a/systemd/insaned.service
+++ b/systemd/insaned.service
@@ -9,6 +9,7 @@ User=root
 Group=root
 Nice=0
 ExecStart=/usr/bin/insaned -p /var/run/insaned/insaned.pid ${INSANED_EXTRAOPTS}
+PIDFile=/var/run/insaned/insaned.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As per https://www.freedesktop.org/software/systemd/man/systemd.service.html#PIDFile=, explicitly specify the PID file.

This helps systemctl keep track of the processes, especially when restarted a few times within a short interval.

Tested on Debian 8.