### PR TITLE
fix: rescan for available devices when scanner is unavailable

### DIFF
--- a/src/InsaneDaemon.h
+++ b/src/InsaneDaemon.h
@@ -116,6 +116,9 @@ private:
     /// SANE version
     SANE_Int mVersionCode = 0;
 
+    /// device is set be the user
+    bool device_fixed = true;
+
     /// Device to use
     std::string mCurrentDevice = "";
 

--- a/src/InsaneDaemon.h
+++ b/src/InsaneDaemon.h
@@ -107,6 +107,9 @@ private:
     /// Timeout in ms to suspend main loop when device is busy
     static const int BUSY_TIMEOUT_MS;
 
+    /// Time in ms to sleep when scanner is offline
+    static const int OFF_SLEEP_MS;
+
     /// Singleton instance
     static InsaneDaemon mInstance;
 
@@ -212,7 +215,7 @@ private:
      *
      * @param name sensor name
      */
-    void process_event(std::string name);
+    void process_event(const std::string& nam, bool debounce = true);
 
     /**
      * Signal handler

--- a/src/InsaneException.h
+++ b/src/InsaneException.h
@@ -26,6 +26,11 @@
 #include <string>
 #include <stdexcept>
 
+enum class InsaneErrorType
+{
+    GENERAL=0,
+    OPEN_DEVICE=1
+};
 
 /**
  * The InsaneException class
@@ -33,9 +38,10 @@
 class InsaneException : std::exception
 {
 public:
-    InsaneException(std::string message)
+    InsaneException(std::string message, InsaneErrorType errorType=InsaneErrorType::GENERAL)
         : std::exception(),
-          mMessage(message) {
+          mMessage(message),
+          mType(errorType) {
     }
 
     virtual ~InsaneException();
@@ -44,8 +50,13 @@ public:
         return mMessage.c_str();
     }
 
+    InsaneErrorType type() const  {
+        return mType;
+    }
+
 private:
     std::string mMessage;
+    InsaneErrorType mType;
 };
 
 #endif


### PR DESCRIPTION
Insaned starts up and continues running even if scanner is powered off. If no device is given, insaned continuously scans for devices. In addition this change introduces two new events (on,off) that are executed when insaned detects a new device and when it looses the connection.